### PR TITLE
Update the version of `org.freedesktop.Platform`

### DIFF
--- a/com.thebrokenrail.MCPIReborn.yml
+++ b/com.thebrokenrail.MCPIReborn.yml
@@ -10,7 +10,7 @@ tags:
 # Runtime/SDK
 runtime: org.freedesktop.Platform
 # Newer Runtimes Don't Support ARM Multiarch
-runtime-version: '19.08'
+runtime-version: '21.08'
 sdk: org.freedesktop.Sdk
 
 # Startup Command


### PR DESCRIPTION
I was prompted with 
```
Info: org.freedesktop.Platform//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
Info: org.freedesktop.Platform.GL.default//19.08 is end-of-life, with reason:
   The Freedesktop SDK 19.08 runtime is no longer supported as of September 1, 2021. Please ask your application developer to migrate to a supported version
```
Trying to update the version